### PR TITLE
Change the restrictions on 'child' items - they should be moveable, but ...

### DIFF
--- a/ganttTask.js
+++ b/ganttTask.js
@@ -112,7 +112,7 @@ Task.prototype.setPeriod = function (start, end) {
   var sups = this.getSuperiors();
   if (sups && sups.length > 0) {
 
-    var supEnd = 0;
+    var supEnd = start;
     for (var i=0;i<sups.length;i++) {
       var link = sups[i];
       supEnd = Math.max(supEnd, incrementDateByWorkingDays(link.from.end, link.lag));


### PR DESCRIPTION
...not earlier than the parent.

![image](https://f.cloud.github.com/assets/365751/117402/dafcf152-6c39-11e2-9b12-0bd1cc7d8dd4.png)

For example, scheduling the "last" project here should allow you to move it later, but not earlier than its parents.

Rescheduling the middle projects should automatically push the child project out.
