### PR TITLE
Refactor the gantt task model to avoid work in the constructor.

### DIFF
--- a/ganttGridEditor.js
+++ b/ganttGridEditor.js
@@ -29,6 +29,8 @@ function GridEditor(master) {
 
 
 GridEditor.prototype.fillEmptyLines = function() {
+  var factory = new TaskFactory();
+
   //console.debug("GridEditor.fillEmptyLines");
   var rowsToAdd = 30 - this.element.find(".taskEditRow").size();
 
@@ -50,7 +52,7 @@ GridEditor.prototype.fillEmptyLines = function() {
 
       //fill all empty previouses
       emptyRow.prevAll(".emptyRow").andSelf().each(function() {
-        var ch = new Task("tmp_fk" + new Date().getTime(), "", "", level, start, 1);
+        var ch = factory.build("tmp_fk" + new Date().getTime(), "", "", level, start, 1);
         var task = master.addTask(ch);
         lastTask = ch;
       });

--- a/ganttMaster.js
+++ b/ganttMaster.js
@@ -110,6 +110,8 @@ GanttMaster.prototype.init = function(place) {
 
 
   }).bind("addAboveCurrentTask.gantt", function() {
+    var factory = new TaskFactory();
+
     var ch;
     var row = 0;
     if (self.currentTask) {
@@ -117,10 +119,10 @@ GanttMaster.prototype.init = function(place) {
       if (self.currentTask.level<=0)
         return;
 
-      ch = new Task("tmp_" + new Date().getTime(), "", "", self.currentTask.level, self.currentTask.start, 1);
+      ch = factory.build("tmp_" + new Date().getTime(), "", "", self.currentTask.level, self.currentTask.start, 1);
       row = self.currentTask.getRow();
     } else {
-      ch = new Task("tmp_" + new Date().getTime(), "", "", 0, new Date().getTime(), 1);
+      ch = factory.build("tmp_" + new Date().getTime(), "", "", 0, new Date().getTime(), 1);
     }
     self.beginTransaction();
     var task = self.addTask(ch, row);
@@ -131,14 +133,15 @@ GanttMaster.prototype.init = function(place) {
     self.endTransaction();
 
   }).bind("addBelowCurrentTask.gantt", function() {
+    var factory = new TaskFactory();
     self.beginTransaction();
     var ch;
     var row = 0;
     if (self.currentTask) {
-      ch = new Task("tmp_" + new Date().getTime(), "", "", self.currentTask.level + 1, self.currentTask.start, 1);
+      ch = factory.build("tmp_" + new Date().getTime(), "", "", self.currentTask.level + 1, self.currentTask.start, 1);
       row = self.currentTask.getRow() + 1;
     } else {
-      ch = new Task("tmp_" + new Date().getTime(), "", "", 0, new Date().getTime(), 1);
+      ch = factory.build("tmp_" + new Date().getTime(), "", "", 0, new Date().getTime(), 1);
     }
     var task = self.addTask(ch, row);
     if (task) {
@@ -207,8 +210,9 @@ GanttMaster.messages = {
 
 
 GanttMaster.prototype.createTask = function (id, name, code, level, start, duration) {
-  var task2 = new Task(id, name, code, level, start, duration);
-  return task2;
+  var factory = new TaskFactory();
+
+  return factory.build(id, name, code, level, start, duration);
 };
 
 
@@ -318,13 +322,14 @@ GanttMaster.prototype.loadProject = function(project) {
 
 
 GanttMaster.prototype.loadTasks = function(tasks, selectedRow) {
+  var factory = new TaskFactory();
   //reset
   this.reset();
 
   for (var i=0;i<tasks.length;i++){
     var task = tasks[i];
     if (!(task instanceof Task)) {
-      var t = new Task(task.id, task.name, task.code, task.level, task.start, task.duration);
+      var t = factory.build(task.id, task.name, task.code, task.level, task.start, task.duration);
       for (var key in task) {
         if (key!="end" && key!="start")
           t[key] = task[key]; //copy all properties

--- a/ganttTask.js
+++ b/ganttTask.js
@@ -22,29 +22,43 @@
 */
 
 /**
- * @todo Avoid work in the constructor (computeStart, computeEndByDuration)
+ * A method to instantiate valid task models from
+ * raw data.
  */
-function Task(id, name, code, level, start, duration) {
+function TaskFactory() {
+
+  /**
+   * Build a new Task
+   */
+  this.build = function(id, name, code, level, start, duration) {
+    // Set at beginning of day
+    var adjusted_start = computeStart(start);
+    var calculated_end = computeEndByDuration(adjusted_start, duration);
+
+    return new Task(id, name, code, level, adjusted_start, calculated_end, duration);
+  };
+
+}
+
+function Task(id, name, code, level, start, end, duration) {
   this.id = id;
   this.name = name;
   this.code = code;
   this.level = level;
   this.status = "STATUS_UNDEFINED";
 
-  this.start = computeStart(start);  //set at the beginning of the day
+  this.start = start
   this.duration = duration;
-  this.end = computeEndByDuration(this.start, this.duration); // to be computed
+  this.end = end;
 
   this.startIsMilestone = false;
   this.endIsMilestone = false;
 
   this.collapsed = false;
   
-
   this.rowElement; //row editor html element
   this.ganttElement; //gantt html element
   this.master;
-
 
   this.assigs = [];
 }


### PR DESCRIPTION
- Introduce a factory to do initial calculating.
- Refactor all new Task() calls to use the factory, maintaining BC.
- Change task constructor signature, to be not much more than a glorified accessor.

Why? I have a need to introduce a different set of behaviours (externally fixed duration tasks, no auto pushing tasks out according to their dependencies).
This PR allows the wiring up to be separated, retaining the previous behaviour by default - other factories can wire up tasks differently.

Not really sure if it's more appropriate as a stand alone factory, or better suited to GanttMaster at the moment - went standalone for simplicity.
