### PR TITLE
minor improvement to indenting a task

### DIFF
--- a/ganttTask.js
+++ b/ganttTask.js
@@ -748,6 +748,12 @@ Task.prototype.indent = function() {
       } else
         break;
     }
+
+    var parent = this.getParent();
+    if(parent && this.start < parent.start && parent.depends && !this.depends){
+    	var new_end = computeEndByDuration(parent.start, this.duration);
+    	this.master.changeTaskDates(this, parent.start, new_end);
+    }
     //recompute depends string
     this.master.updateDependsStrings();
     //enlarge parent using a fake set period


### PR DESCRIPTION
when you try to indent a task onto a parent that has dependencies, if
the current task's start date is before the parent's date, it blocks the
indentation due to date constraints.  This addition shifts the task's
dates to be inline with the parent's dates when there are no other
dependency concerns
