### PR TITLE
Remove 12 hour subtraction from computeEnd func

### DIFF
--- a/ganttUtilities.js
+++ b/ganttUtilities.js
@@ -189,7 +189,7 @@ $.splittify = {
   }
 
   function computeEnd(end) {
-    var d = new Date(end-3600000*12);
+    var d = new Date(end);
     d.setHours(23, 59, 59, 999);
     //move to next working day
     while (isHoliday(d)) {


### PR DESCRIPTION
When updating an end date directly, the computeEnd function was subtracting twelve hours from the provided value, which moved it into the previous day (since the value comes in as 12am).

The d.setHours that already existed presumably does everything that the subtraction was intended to do.

The problem with the current behaviour can be seen at http://gantt.twproject.com/distrib/gantt.html - just change the end date for the "gant part" ahead by a couple of days (it looks like the dates on this page are dynamic, so currently for me that involves changing from 5th Feb to 7th Feb) and then click somewhere else on the page, the date changes to the date before the selected one (ie 6th Feb).
