### PR TITLE
Performance issue fix within addTask() due to nested loop of DOM manipulation

### DIFF
--- a/ganttGridEditor.js
+++ b/ganttGridEditor.js
@@ -103,9 +103,9 @@ GridEditor.prototype.addTask = function (task, row, hideIfParentCollapsed) {
     }
 
   }
-  this.element.find(".taskRowIndex").each(function (i, el) {
-    $(el).html(i + 1);
-  });
+  // this.element.find(".taskRowIndex").each(function (i, el) {
+  //   $(el).html(i + 1);
+  // });
   //prof.stop();
 
 


### PR DESCRIPTION
Upon initilization, the amount of tasks (rows) in use determine how many
times GridEditor.prototype.addTask() will be called and once it's called
it would do another a each loop, which leads to piles of redundant loops
on stack, slowing down the performance in especially in IE9 if you have
a project with 200+ tasks. I didn't see practical use of this each loop
because the row index is always updated so I'd recommend comment it out.
