### PR TITLE
BUG FIX: ganttElement is undefined

### DIFF
--- a/ganttTask.js
+++ b/ganttTask.js
@@ -723,9 +723,16 @@ Task.prototype.getInferiorTasks = function() {
 };
 
   Task.prototype.deleteTask = function() {
+  
   //delete both dom elements
-  this.rowElement.remove();
-  this.ganttElement.remove();
+  if (this.rowElement) {
+    this.rowElement.remove();
+  }
+
+  //delete both dom elements
+  if (this.ganttElement) {
+    this.ganttElement.remove();
+  }
 
   //remove children
   var chd = this.getChildren();


### PR DESCRIPTION
Added if statement checking if rowElement and ganttElement variables in
ganttTask are populated before removal.
This caused errors in some situations.