### PR TITLE
Enhanced to support different date formats

### DIFF
--- a/ganttDrawerSVG.js
+++ b/ganttDrawerSVG.js
@@ -539,6 +539,13 @@ Ganttalendar.prototype.drawTask = function (task) {
 
   function _createTaskSVG(task, dimensions) {
     var svg = self.svg;
+
+	if (task.isMileStone) {
+		var taskSvg = svg.svg(self.tasksGroup, dimensions.x, dimensions.y, dimensions.width, dimensions.height, {class: 'taskBox', status: task.status, taskid: task.id});
+		svg.image(taskSvg, '100%', dimensions.height/2-9, 18, 18, self.master.resourceUrl+'milestone.png', {transform: 'translate(-20)'})
+		return taskSvg;
+	}
+
     var taskSvg = svg.svg(self.tasksGroup, dimensions.x, dimensions.y, dimensions.width, dimensions.height, {class:"taskBox taskBoxSVG taskStatusSVG", status:task.status, taskid:task.id });
 
     //svg.title(taskSvg, task.name);

--- a/ganttGridEditor.js
+++ b/ganttGridEditor.js
@@ -161,7 +161,9 @@ GridEditor.prototype.refreshTaskRow = function (task) {
   if(duration == 0) {
       duration = duration+1;
   } else if(duration < 0) { // if end date is null or less than start date
-      duration = 0; 
+      duration = 0;
+  } else if (duration && task.isMileStone) {
+	  duration = 0;
   }
 
   var dateFormat = this.master.dateFormat;

--- a/ganttGridEditor.js
+++ b/ganttGridEditor.js
@@ -146,6 +146,8 @@ GridEditor.prototype.refreshTaskRow = function (task) {
   //console.debug("refreshTaskRow")
   //var profiler = new Profiler("editorRefreshTaskRow");
   var row = task.rowElement;
+  task.oldstart = row.find("[name=start]").text();//setting start old value
+  task.oldend = row.find("[name=end]").text();//setting end old value
 
   row.find(".taskRowIndex").html(task.getRow() + 1);
   row.find(".indentCell").css("padding-left", task.level * 10 +18 );
@@ -153,9 +155,22 @@ GridEditor.prototype.refreshTaskRow = function (task) {
   row.find("[name=code]").val(task.code);
   row.find("[status]").attr("status", task.status);
 
+  var difference = task.end - task.start;
+  var duration = Math.floor(difference/(3600*24*1000)+1);
+  // if the start date and end date are same
+  if(duration == 0) {
+      duration = duration+1;
+  } else if(duration < 0) { // if end date is null or less than start date
+      duration = 0; 
+  }
+
+  var dateFormat = this.master.dateFormat;
+  var startDate = new Date(task.start).format(dateFormat);
+  var endDate = new Date(task.end).format(dateFormat);
+
+  row.find("[name=start]").val(startDate).updateOldValue(); // called on dates only because for other field is called on focus event
+  row.find("[name=end]").val(endDate).updateOldValue();
   row.find("[name=duration]").val(task.duration);
-  row.find("[name=start]").val(new Date(task.start).format()).updateOldValue(); // called on dates only because for other field is called on focus event
-  row.find("[name=end]").val(new Date(task.end).format()).updateOldValue();
   row.find("[name=depends]").val(task.depends);
   row.find(".taskAssigs").html(task.getAssigsString());
 

--- a/ganttMaster.js
+++ b/ganttMaster.js
@@ -52,6 +52,7 @@ function GanttMaster() {
   this.__inUndoRedo = false; // a control flag to avoid Undo/Redo stacks reset when needed
 
   var self = this;
+  this.dateFormat = 'dd/MM/yyyy';
 }
 
 
@@ -373,6 +374,10 @@ GanttMaster.prototype.loadProject = function (project) {
     this.maxEditableDate = computeEnd(project.maxEditableDate);
   else
     this.maxEditableDate = Infinity;
+
+  if ('dateFormat' in project) {//checking isset or not
+	this.dateFormat = project.dateFormat;
+  }
 
   this.loadTasks(project.tasks, project.selectedRow);
   this.deletedTaskIds = [];


### PR DESCRIPTION
Enhance to show start & end dates in different format as line 54 in _[https://github.com/robicch/jQueryGantt/blob/master/libs/date.js](https://github.com/robicch/jQueryGantt/blob/master/libs/date.js)_

issue : [#issue62](https://github.com/robicch/jQueryGantt/issues/62)

**supporting date formats:**
'dd/MM/yyyy', 'y-M-d', 'MMM d, y', 'MMM d,y', 'y-MMM-d', 'd-MMM-y', 'MMM d', 'MMM-d', 'd-MMM', 'M/d/y', 'M-d-y', 'M.d.y', 'M/d', 'M-d', 'd/M/y', 'd-M-y', 'd.M.y', 'd/M', 'd-M', etc..

issue : [#issue68](https://github.com/robicch/jQueryGantt/issues/68)
I had fixed another issue also which enhancement added to differentiation between milestone and task's UI in chart
