### PR TITLE
Enhanced to show gantt icons, if gantt folder placed in a different path

### DIFF
--- a/ganttMaster.js
+++ b/ganttMaster.js
@@ -52,6 +52,7 @@ function GanttMaster() {
   this.__inUndoRedo = false; // a control flag to avoid Undo/Redo stacks reset when needed
 
   var self = this;
+  this.libPath = '';//URL to library path 
 }
 
 
@@ -373,6 +374,11 @@ GanttMaster.prototype.loadProject = function (project) {
     this.maxEditableDate = computeEnd(project.maxEditableDate);
   else
     this.maxEditableDate = Infinity;
+
+  if ('libPath' in project) {//isset in the project or not
+	this.libPath = project.libPath;
+	this.resourceUrl = this.libPath+this.resourceUrl;
+  }
 
   this.loadTasks(project.tasks, project.selectedRow);
   this.deletedTaskIds = [];


### PR DESCRIPTION
Gantt icons are not loading if I placed gantt folder in a different path like 'libraries/jQuery/gantt'
issue : [#issue64](https://github.com/robicch/jQueryGantt/issues/64)
