### PR TITLE
Fixes #87

### DIFF
--- a/ganttUtilities.js
+++ b/ganttUtilities.js
@@ -293,7 +293,7 @@ $.splittify = {
       firstBox.find(".ganttFixHead").css('top', top);
       secondBox.find(".ganttFixHead").css('top', top);
 
-      where.stopTime("reset").oneTime(100, "reset", function () {stopScroll = "";})
+      where.stopTime("reset").oneTime(300, "reset", function () {stopScroll = "";})
     });
 
 


### PR DESCRIPTION
Increasing the time interval fixes the issue #87. 100ms is not sufficient breathing space to fix the header top position when user has loaded more than large number of tasks on the grid and when has some other customization applied. It is more visible on IE browser.