### PR TITLE
Fix Issue#104

### DIFF
--- a/ganttUtilities.js
+++ b/ganttUtilities.js
@@ -316,6 +316,9 @@ $.splittify = {
       event.preventDefault();
 
       var deltaY = event.originalEvent.wheelDeltaY;
+      if(!deltaY)
+          deltaY=event.originalEvent.wheelDelta; 
+      
       var deltaX = event.originalEvent.wheelDeltaX;
 
       if (event.originalEvent.axis) {


### PR DESCRIPTION
On IE <=11, the **wheelDeltaY** property is 'undefined' on mousewheel event but you can find the correct value  on **wheelDelta** property. 
So in case user is on IE < 11 we can have a fall back code as

```
var deltaY = event.originalEvent.wheelDeltaY;
            if (!deltaY)
                deltaY = event.originalEvent.wheelDelta;
```