### PR TITLE
Fix to delete Tasks - ganttMaster.js

### DIFF
--- a/ganttMaster.js
+++ b/ganttMaster.js
@@ -117,10 +117,11 @@ GanttMaster.prototype.init = function (workSpace) {
   }).bind("deleteFocused.gantt", function (e) {
     //delete task or link?
     var focusedSVGElement=self.gantt.element.find(".focused.focused.linkGroup");
-    if (focusedSVGElement.size()>0)
+    if (focusedSVGElement.size()>0) {
       self.removeLink(focusedSVGElement.data("from"), focusedSVGElement.data("to"));
-    else
+    } else {
     self.deleteCurrentTask();
+    }
   }).bind("addAboveCurrentTask.gantt", function () {
     self.addAboveCurrentTask();
   }).bind("addBelowCurrentTask.gantt", function () {


### PR DESCRIPTION
Added brackets in the "deleteFocused.gantt" if-function. 

Without those brackets I could only delete links but not tasks. 

Used Browser Firefox 56 Ubuntu 17.10.