### PR TITLE
Fix 'ch is not defined' error for moveTo() method in some cases

### DIFF
--- a/ganttTask.js
+++ b/ganttTask.js
@@ -329,7 +329,7 @@ Task.prototype.moveTo = function (start, ignoreMilestones) {
     //loops children to shift them
     var children = this.getChildren();
     for (var i = 0; i < children.length; i++) {
-      ch = children[i];
+      var ch = children[i];
       var chStart=new Date(ch.start).incrementDateByWorkingDays(panDeltaInWD);
       if (!ch.moveTo(chStart, false)) {
         //console.debug("esco")


### PR DESCRIPTION
FYI

<img width="594" alt="error_moveto" src="https://user-images.githubusercontent.com/22103256/33242580-8db7a14e-d2d7-11e7-91d4-9789b8bab62d.png">
