### PR TITLE
Fix composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "robicch/jQueryGantt",
+    "name": "robicch/jquery-gantt",
     "description": "Twproject Gantt editor is a free online tool for creating and sharing Gantts",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
The previous selected package name was not valid accordingly to packagist naming conventions.
