### PR TITLE
fix printing bug about "taskLinkPathSVG"

### DIFF
--- a/ganttMaster.js
+++ b/ganttMaster.js
@@ -1404,7 +1404,9 @@ GanttMaster.prototype.saveRequired = function () {
 
 GanttMaster.prototype.print = function () {
   this.gantt.redrawTasks(true);
-  print();
+ // Wait until the redrawing task is over before printing, or the SVG links may not be printed.
+  setTimeout(function(){print()}, 1000);
+
 };
 
 


### PR DESCRIPTION
Expected behavior when click "print":<img width="774" alt="img1" src="https://user-images.githubusercontent.com/25281816/124379754-65e71380-dceb-11eb-82f2-66f4e4370f90.png">
Actual behavior:
<img width="753" alt="img2" src="https://user-images.githubusercontent.com/25281816/124379775-89aa5980-dceb-11eb-8fa4-72d7dd67bd64.png">
It seems "taskLinkPathSVG" is not printed at all due to an asynchronous problem, that is ,the printting function  executed before the redrawing task is finished. So the SVG path is not printed at all.
The best solution is rewriting the redrawing function to async function as there is a [non-block timer](https://github.com/robicch/jQueryGantt/blob/master/ganttDrawerSVG.js#L672-L697), it dosen't wait for this timer. but there should be too much work to do.So add a settimeout as a dirty hack to let printting  "wait one second" for  drawing function.